### PR TITLE
Add udp destination ip+port

### DIFF
--- a/src/integrations/linux/netlink_iterator.rs
+++ b/src/integrations/linux/netlink_iterator.rs
@@ -144,6 +144,8 @@ unsafe fn parse_diag_msg(diag_msg: &inet_diag_msg, protocol: __u8, rtalen: usize
             protocol_socket_info: ProtocolSocketInfo::Udp(UdpSocketInfo {
                 local_addr: src_ip,
                 local_port: src_port,
+                remote_addr: dst_ip,
+                remote_port: dst_port,
             }),
             associated_pids: Vec::with_capacity(0),
             inode: diag_msg.inode,

--- a/src/integrations/osx/netstat.rs
+++ b/src/integrations/osx/netstat.rs
@@ -105,6 +105,8 @@ fn parse_line(
             protocol_socket_info: ProtocolSocketInfo::Udp(UdpSocketInfo {
                 local_addr: parse_ip(local_addr, is_ipv4)?,
                 local_port: parse_port(local_port)?,
+                remote_addr: parse_ip(remote_addr, is_ipv4)?,
+                remote_port: parse_port(remote_port)?,
             }),
             associated_pids: vec![
                 pid.parse::<u32>()

--- a/src/integrations/windows/socket_table.rs
+++ b/src/integrations/windows/socket_table.rs
@@ -77,6 +77,8 @@ impl SocketTable for MIB_UDPTABLE_OWNER_PID {
             protocol_socket_info: ProtocolSocketInfo::Udp(UdpSocketInfo {
                 local_addr: IpAddr::V4(Ipv4Addr::from(u32::from_be(row.local_addr))),
                 local_port: u16::from_be(row.local_port as u16),
+                remote_addr: IpAddr::V4(Ipv4Addr::from(u32::from_be(row.remote_addr))),
+                remote_port: u16::from_be(row.remote_port as u16),
             }),
             associated_pids: vec![row.owning_pid],
         }

--- a/src/types/socket_info.rs
+++ b/src/types/socket_info.rs
@@ -53,4 +53,6 @@ pub struct TcpSocketInfo {
 pub struct UdpSocketInfo {
     pub local_addr: IpAddr,
     pub local_port: u16,
+    pub remote_addr: IpAddr,
+    pub remote_port: u16,
 }


### PR DESCRIPTION
Hey @ivxvm !

I'm very happy with this library and would like to add the possibility to log udp destination ip + port.
With these changes, this happens successfully for me on linux, but unfortunately I do not have access to a windows/mac machine to test it there. So I hope I did the right thing with them. :)

Please let me know if you'd like me to change anything - and once again, thanks for this cool lib!