### PR TITLE
set_len on table vec, and clean up redundant code

### DIFF
--- a/src/integrations/windows/socket_table.rs
+++ b/src/integrations/windows/socket_table.rs
@@ -108,29 +108,22 @@ impl SocketTable for MIB_UDP6TABLE_OWNER_PID {
 
 fn get_extended_tcp_table(address_family: ULONG) -> Result<Vec<u8>, Error> {
     let mut table_size: DWORD = 0;
-    let mut err_code = unsafe {
-        GetExtendedTcpTable(
-            std::ptr::null_mut(),
-            &mut table_size,
-            FALSE,
-            address_family,
-            TCP_TABLE_OWNER_PID_ALL,
-            0,
-        )
-    };
+    let mut err_code = ERROR_INSUFFICIENT_BUFFER;
     let mut table = Vec::<u8>::new();
     let mut iterations = 0;
     while err_code == ERROR_INSUFFICIENT_BUFFER {
         table = Vec::<u8>::with_capacity(table_size as usize);
         err_code = unsafe {
-            GetExtendedTcpTable(
+            let ret = GetExtendedTcpTable(
                 table.as_mut_ptr() as PVOID,
                 &mut table_size,
                 FALSE,
                 address_family,
                 TCP_TABLE_OWNER_PID_ALL,
                 0,
-            )
+            );
+            table.set_len(table_size as usize);
+            ret
         };
         iterations += 1;
         if iterations > 100 {
@@ -151,29 +144,22 @@ fn get_extended_tcp_table(address_family: ULONG) -> Result<Vec<u8>, Error> {
 
 fn get_extended_udp_table(address_family: ULONG) -> Result<Vec<u8>, Error> {
     let mut table_size: DWORD = 0;
-    let mut err_code = unsafe {
-        GetExtendedUdpTable(
-            std::ptr::null_mut(),
-            &mut table_size,
-            FALSE,
-            address_family,
-            UDP_TABLE_OWNER_PID,
-            0,
-        )
-    };
+    let mut err_code = ERROR_INSUFFICIENT_BUFFER;
     let mut table = Vec::<u8>::new();
     let mut iterations = 0;
     while err_code == ERROR_INSUFFICIENT_BUFFER {
         table = Vec::<u8>::with_capacity(table_size as usize);
         err_code = unsafe {
-            GetExtendedUdpTable(
+            let ret = GetExtendedUdpTable(
                 table.as_mut_ptr() as PVOID,
                 &mut table_size,
                 FALSE,
                 address_family,
                 UDP_TABLE_OWNER_PID,
                 0,
-            )
+            );
+            table.set_len(table_size as usize);
+            ret
         };
         iterations += 1;
         if iterations > 100 {


### PR DESCRIPTION
I discovered what appears to be a bug in the table Vector sizing. Calling `Vec::with_capacity` creates the empty buffer, however, the call to `GetExtendedTcpTable` (and the UPD alternative) do not modify the mutable `table` Vec's len.

For that, you need to `set_len` on the Vec, using the modified `table_size`. 

I also noticed there was some redundancy in the explicit calls to the get-table functions, where they start by calling it with a null ptr for the table, which will always return `ERROR_INSUFFICIENT_BUFFER`; my changes here don't change the fact it'll still start with an empty table and get `ERROR_INSUFFICIENT_BUFFER` on the first call, but it gets rid of some unnecessary code by initializing `err_code` to `ERROR_INSUFFICIENT_BUFFER` to begin with.

Here is a pastebin from an example I wrote to demonstrate the issue:
https://pastebin.com/A42i5xuT